### PR TITLE
refactor: consolidate test deps into dev group and simplify ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,15 +45,6 @@ Homepage = "https://github.com/imleowoo/httpbinx"
 # Documentation = ""
 Repository = "https://github.com/imleowoo/httpbinx"
 
-[project.optional-dependencies]
-test = [
-    "httpx",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-xdist",
-    "pytest",
-]
-
 [tool.pdm]
 version = { source = "file", path = "httpbinx/__init__.py" }
 distribution = true
@@ -61,14 +52,10 @@ distribution = true
 [tool.ruff]
 target-version = "py314"
 line-length = 120
-exclude = ["*_pb2*.py", "*.pb2.py", "anyproto", "commonproto", "taskpool"]
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "N", "D101"]
 ignore = []
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["F401", "F811", "I001"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
@@ -78,5 +65,10 @@ quote-style = "single"
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15.12",
+    "ruff",
+    "httpx",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-xdist",
+    "pytest",
 ]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,8 @@
 """Tag: Auth"""
 
-import pytest
 from base64 import b64encode
 
+import pytest
 from starlette import status
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -299,17 +299,13 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
-test = [
+[package.dev-dependencies]
+dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
-]
-
-[package.dev-dependencies]
-dev = [
     { name = "ruff" },
 ]
 
@@ -317,21 +313,22 @@ dev = [
 requires-dist = [
     { name = "brotli" },
     { name = "fastapi" },
-    { name = "httpx", marker = "extra == 'test'" },
     { name = "jinja2" },
     { name = "pydantic" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "pytest-mock", marker = "extra == 'test'" },
-    { name = "pytest-xdist", marker = "extra == 'test'" },
     { name = "python-multipart" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-provides-extras = ["test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.12" }]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "pytest-xdist" },
+    { name = "ruff" },
+]
 
 [[package]]
 name = "httpcore"


### PR DESCRIPTION
- Move httpx, pytest, pytest-cov, pytest-mock, pytest-xdist from optional-dependencies into the dev dependency group
- Remove ruff exclude and per-file-ignores config
- Remove ruff version pin