### PR TITLE
chore: ignore local-only *.local.md guidance files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ temp/
 
 # VS Code configuration file
 .vscode/
+
+# Local-only Claude guidance (not committed)
+*.local.md


### PR DESCRIPTION
Add a gitignore rule so local Claude guidance documents are never tracked or pushed to the remote.