### PR TITLE
fix(base64): return 400 instead of 500 for valid base64 that decodes to non-UTF-8 bytes

### DIFF
--- a/src/httpbinx/routers/dynamicdata.py
+++ b/src/httpbinx/routers/dynamicdata.py
@@ -43,7 +43,7 @@ async def decode_base64(
     try:
         decoded = base64.urlsafe_b64decode(encoded).decode('utf-8')
         return PlainTextResponse(content=decoded)
-    except binascii.Error as err:
+    except (binascii.Error, UnicodeDecodeError) as err:
         return PlainTextResponse(
             content=f'Incorrect Base64 data: {value}, err_msg: {err}', status_code=status.HTTP_400_BAD_REQUEST
         )

--- a/tests/test_dynamic_data.py
+++ b/tests/test_dynamic_data.py
@@ -23,6 +23,14 @@ class TestBase64:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert 'Incorrect Base64 data' in response.text
 
+    def test_valid_base64_non_utf8_bytes(self, client):
+        # 'vO2Tie4=' is valid base64url that decodes to bytes which are not
+        # valid UTF-8. The decode('utf-8') step used to raise UnicodeDecodeError
+        # and bubble up as a 500 instead of the intended 400.
+        response = client.get('/base64/vO2Tie4=')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'Incorrect Base64 data' in response.text
+
 
 class TestBytes:
     """Tests for the /bytes endpoint."""


### PR DESCRIPTION
Ran into this hitting `/base64/vO2Tie4=` and getting a 500 back.

The handler only catches `binascii.Error`, but `vO2Tie4=` is perfectly valid base64url. It just decodes to bytes that aren't valid UTF-8, so `.decode('utf-8')` throws `UnicodeDecodeError` and that escapes as a 500. Other bad input (like `!!!invalid!!!`) already returns a clean 400, so this felt inconsistent.

Fix is just adding `UnicodeDecodeError` to the except so those values get the same 400 'Incorrect Base64 data' response.

Added a test for it in `TestBase64` (`vO2Tie4=` -> 400). It fails on main and passes with the change, and the rest of `test_dynamic_data.py` still passes.

Fixes #86